### PR TITLE
BGC updates for the 0.1-degree run and IAMIP2

### DIFF
--- a/bld/build.sh
+++ b/bld/build.sh
@@ -116,8 +116,8 @@ setenv NTRAERO 0          # number of aerosol tracers
                           # (up to max_aero in ice_domain_size.F90) 
                           # CESM uses 3 aerosol tracers
 setenv TRBRI   0          # set to 1 for brine height tracer
-setenv NBGCLYR 7          # number of zbgc layers
-setenv TRBGCS  0          # number of skeletal layer bgc tracers 
+setenv NBGCLYR 0          # number of zbgc layers
+setenv TRBGCS  2          # number of skeletal layer bgc tracers 
                           # TRBGCS=0 or 2<=TRBGCS<=9)
 
 ### File unit numbers

--- a/bld/build.sh
+++ b/bld/build.sh
@@ -115,7 +115,7 @@ setenv TRPND   1          # set to 1 for melt pond tracers
 setenv NTRAERO 0          # number of aerosol tracers 
                           # (up to max_aero in ice_domain_size.F90) 
                           # CESM uses 3 aerosol tracers
-setenv TRBRI   0          # set to 1 for brine height tracer
+setenv TRBRI   1          # set to 1 for brine height tracer
 setenv NBGCLYR 0          # number of zbgc layers
 setenv TRBGCS  2          # number of skeletal layer bgc tracers 
                           # TRBGCS=0 or 2<=TRBGCS<=9)

--- a/drivers/auscom/cpl_arrays_setup.F90
+++ b/drivers/auscom/cpl_arrays_setup.F90
@@ -32,6 +32,7 @@ module cpl_arrays_setup
 ! (6) sea surface gradient (meridional)(m/m)            ssly
 ! (7) potential ice frm/mlt heatflux (W/m^2)            pfmice
 ! (8) sea surface nitrate (mmol/m^3)                    ssn
+! (9) sea surface algae/phytoplankton (mmol/m^3)                    ssalg
 !
 ! D> ice==>ocn
 !             
@@ -72,6 +73,7 @@ module cpl_arrays_setup
 ! BGC tracers
 !
 !(19) nitrate in sea ice                                ionit
+!(20) algae in sea ice                                ioalg
 !
 !
 
@@ -102,7 +104,7 @@ real(kind=dbl_kind), dimension(:,:,:), allocatable :: &
     core_runoff
 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: &   !from ocn
-    ssto,  ssso,   ssuo,   ssvo,   sslx,  ssly,  pfmice, ssn 
+    ssto,  ssso,   ssuo,   ssvo,   sslx,  ssly,  pfmice, ssn, ssalg
 real(kind=dbl_kind), dimension(:,:), allocatable :: gwork
     !global domain work array, used for coupling data passing and global data output. 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: vwork  
@@ -110,11 +112,11 @@ real(kind=dbl_kind), dimension(:,:,:), allocatable :: vwork
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: &     !to ocn (time averaged)
     iostrsu, iostrsv, iorain, iosnow, iostflx, iohtflx, ioswflx &
    ,ioqflux, ioshflx, iolwflx, iorunof, iopress, ioaice &
-   ,iomelt, ioform, iolicefw, iolicefh, iownd, ionit
+   ,iomelt, ioform, iolicefw, iolicefh, iownd, ionit, ioalg
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: &     !to ocn (temporary)
     tiostrsu, tiostrsv, tiorain, tiosnow, tiostflx, tiohtflx, tioswflx &
    ,tioqflux, tioshflx, tiolwflx, tiorunof, tiopress, tioaice &
-   ,tiomelt, tioform, tiolicefw, tiolicefh, tiownd, tionit
+   ,tiomelt, tioform, tiolicefw, tiolicefh, tiownd, tionit, tioalg
 
 ! other stuff 
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: & 

--- a/drivers/auscom/cpl_arrays_setup.F90
+++ b/drivers/auscom/cpl_arrays_setup.F90
@@ -31,6 +31,7 @@ module cpl_arrays_setup
 ! (5) sea surface gradient (zonal)     (m/m)            sslx
 ! (6) sea surface gradient (meridional)(m/m)            ssly
 ! (7) potential ice frm/mlt heatflux (W/m^2)            pfmice
+! (8) sea surface nitrate (mmol/m^3)                    nitrateo
 !
 ! D> ice==>ocn
 !             
@@ -68,6 +69,10 @@ module cpl_arrays_setup
 !(17) land ice heatflux                                 iolicefh
 !(18) 10m wind speeds                                   iownd10
 !
+! BGC tracers
+!
+!(19) nitrate in sea ice                                nitratei
+!
 !
 
 !
@@ -97,7 +102,7 @@ real(kind=dbl_kind), dimension(:,:,:), allocatable :: &
     core_runoff
 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: &   !from ocn
-    ssto,  ssso,   ssuo,   ssvo,   sslx,  ssly,  pfmice  
+    ssto,  ssso,   ssuo,   ssvo,   sslx,  ssly,  pfmice, nitrateo 
 real(kind=dbl_kind), dimension(:,:), allocatable :: gwork
     !global domain work array, used for coupling data passing and global data output. 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: vwork  
@@ -105,11 +110,11 @@ real(kind=dbl_kind), dimension(:,:,:), allocatable :: vwork
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: &     !to ocn (time averaged)
     iostrsu, iostrsv, iorain, iosnow, iostflx, iohtflx, ioswflx &
    ,ioqflux, ioshflx, iolwflx, iorunof, iopress, ioaice &
-   ,iomelt, ioform, iolicefw, iolicefh, iownd
+   ,iomelt, ioform, iolicefw, iolicefh, iownd, ionitrate
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: &     !to ocn (temporary)
     tiostrsu, tiostrsv, tiorain, tiosnow, tiostflx, tiohtflx, tioswflx &
    ,tioqflux, tioshflx, tiolwflx, tiorunof, tiopress, tioaice &
-   ,tiomelt, tioform, tiolicefw, tiolicefh, tiownd
+   ,tiomelt, tioform, tiolicefw, tiolicefh, tiownd, tionitrate
 
 ! other stuff 
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: & 

--- a/drivers/auscom/cpl_arrays_setup.F90
+++ b/drivers/auscom/cpl_arrays_setup.F90
@@ -31,7 +31,7 @@ module cpl_arrays_setup
 ! (5) sea surface gradient (zonal)     (m/m)            sslx
 ! (6) sea surface gradient (meridional)(m/m)            ssly
 ! (7) potential ice frm/mlt heatflux (W/m^2)            pfmice
-! (8) sea surface nitrate (mmol/m^3)                    nitrateo
+! (8) sea surface nitrate (mmol/m^3)                    ssn
 !
 ! D> ice==>ocn
 !             
@@ -71,7 +71,7 @@ module cpl_arrays_setup
 !
 ! BGC tracers
 !
-!(19) nitrate in sea ice                                nitratei
+!(19) nitrate in sea ice                                ionit
 !
 !
 
@@ -102,7 +102,7 @@ real(kind=dbl_kind), dimension(:,:,:), allocatable :: &
     core_runoff
 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: &   !from ocn
-    ssto,  ssso,   ssuo,   ssvo,   sslx,  ssly,  pfmice, nitrateo 
+    ssto,  ssso,   ssuo,   ssvo,   sslx,  ssly,  pfmice, ssn 
 real(kind=dbl_kind), dimension(:,:), allocatable :: gwork
     !global domain work array, used for coupling data passing and global data output. 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: vwork  
@@ -110,11 +110,11 @@ real(kind=dbl_kind), dimension(:,:,:), allocatable :: vwork
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: &     !to ocn (time averaged)
     iostrsu, iostrsv, iorain, iosnow, iostflx, iohtflx, ioswflx &
    ,ioqflux, ioshflx, iolwflx, iorunof, iopress, ioaice &
-   ,iomelt, ioform, iolicefw, iolicefh, iownd, ionitrate
+   ,iomelt, ioform, iolicefw, iolicefh, iownd, ionit
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: &     !to ocn (temporary)
     tiostrsu, tiostrsv, tiorain, tiosnow, tiostflx, tiohtflx, tioswflx &
    ,tioqflux, tioshflx, tiolwflx, tiorunof, tiopress, tioaice &
-   ,tiomelt, tioform, tiolicefw, tiolicefh, tiownd, tionitrate
+   ,tiomelt, tioform, tiolicefw, tiolicefh, tiownd, tionit
 
 ! other stuff 
 real(kind=dbl_kind),dimension(:,:,:), allocatable :: & 

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -23,7 +23,7 @@ module cpl_forcing_handler
     use cpl_netcdf_setup
     use cpl_arrays_setup
     use ice_calendar, only: dt
-    use ice_zbgc_shared, only: ocean_bio,nlt_bgc_N,nlt_bgc_NO
+    use ice_zbgc_shared, only: ocean_bio,flux_bio,nlt_bgc_N,nlt_bgc_NO
 
 implicit none
 
@@ -812,9 +812,9 @@ tioswflx = swabs_ocn
 !16 10m wind. To mask or not to mask?
   tiownd(:,:,:) = sqrt(uatm(:,:,:)**2 + vatm(:,:,:)**2)
 !17? sea surface nitrate updated after ice-water flux
-  tionit(:,:,:) = ocean_bio(:,:,nlt_bgc_NO,:)
+  tionit(:,:,:) = flux_bio(:,:,nlt_bgc_NO,:)*aice(:,:,:)
 !18 sea surface algae/phyto/nitrogen updated after ice-water flux
-  tioalg(:,:,:) = ocean_bio(:,:,nlt_bgc_N,:)
+  tioalg(:,:,:) = flux_bio(:,:,nlt_bgc_N,:)*aice(:,:,:)
 
 return
 end subroutine get_i2o_fluxes

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -182,6 +182,7 @@ if ( file_exist(fname) ) then
   call ice_read_nc(ncid_o2i, 1, 'sslx_i',   sslx,   dbug)
   call ice_read_nc(ncid_o2i, 1, 'ssly_i',   ssly,   dbug)
   call ice_read_nc(ncid_o2i, 1, 'pfmice_i', pfmice, dbug)
+  call ice_read_nc(ncid_o2i, 1, 'ssn_i',    ssn, dbug)
   if (my_task == master_task) call ice_close_nc(ncid_o2i)
 else
   print *, 'CICE: (get_time0_o2i_fields_old) not found file *** ',fname
@@ -1266,6 +1267,8 @@ call gather_global(gwork, ssly, master_task, distrb_info)
 if (my_task == 0) call write_nc2D(ncid, 'ssly', gwork, 2, nx_global,ny_global,currstep,ilout=il_out)
 call gather_global(gwork, pfmice, master_task, distrb_info)
 if (my_task == 0) call write_nc2D(ncid, 'pfmice', gwork, 2, nx_global,ny_global,currstep,ilout=il_out)
+call gather_global(gwork, ssn, master_task, distrb_info)
+if (my_task == 0) call write_nc2D(ncid, 'ssn', gwork, 2, nx_global,ny_global,currstep,ilout=il_out)
 
 if (my_task == 0) call ncheck(nf_close(ncid), 'check_o2i_fields: nf_close')
 

--- a/drivers/auscom/cpl_interface.F90
+++ b/drivers/auscom/cpl_interface.F90
@@ -636,6 +636,8 @@ subroutine into_ocn(isteps, scale)
             call pack_coupling_array(iolicefh*scale, work)
         elseif (trim(fields_to_ocn(i)) == 'wnd10_io') then
             call pack_coupling_array(iownd*scale, work)
+        elseif (trim(fields_to_ocn(i)) == 'nitrate_io') then
+            call pack_coupling_array(ionitrate*scale, work)
         else
             call abort_ice('ice: bad coupling array name '//fields_to_ocn(i))
         endif

--- a/drivers/auscom/cpl_interface.F90
+++ b/drivers/auscom/cpl_interface.F90
@@ -292,6 +292,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
     allocate (ssly(nx_block, ny_block, max_blocks));  ssly(:,:,:) = 0
     allocate (pfmice(nx_block, ny_block, max_blocks));  pfmice(:,:,:) = 0
     allocate (ssn(nx_block, ny_block, max_blocks));  ssn(:,:,:) = 0
+    allocate (ssalg(nx_block, ny_block, max_blocks));  ssalg(:,:,:) = 0
 
     allocate (iostrsu(nx_block, ny_block, max_blocks)); iostrsu(:,:,:) = 0
     allocate (iostrsv(nx_block, ny_block, max_blocks)); iostrsv(:,:,:) = 0
@@ -314,6 +315,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
 
     allocate (iownd (nx_block, ny_block, max_blocks)); iownd(:,:,:) = 0
     allocate (ionit (nx_block, ny_block, max_blocks)); ionit(:,:,:) = 0
+    allocate (ioalg (nx_block, ny_block, max_blocks)); ioalg(:,:,:) = 0
 
     allocate (tiostrsu(nx_block, ny_block, max_blocks)); tiostrsu(:,:,:) = 0
     allocate (tiostrsv(nx_block, ny_block, max_blocks)); tiostrsv(:,:,:) = 0
@@ -334,6 +336,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
 
     allocate (tiownd (nx_block, ny_block, max_blocks)); tiownd(:,:,:) = 0
     allocate (tionit (nx_block, ny_block, max_blocks)); tionit(:,:,:) = 0
+    allocate (tioalg (nx_block, ny_block, max_blocks)); tioalg(:,:,:) = 0
 
     allocate (tiolicefw(nx_block, ny_block, max_blocks));  tiolicefw(:,:,:) = 0
     allocate (tiolicefh(nx_block, ny_block, max_blocks));  tiolicefh(:,:,:) = 0
@@ -576,6 +579,8 @@ subroutine from_ocn(isteps)
             call unpack_coupling_array(work, pfmice)
         elseif (trim(fields_from_ocn(i)) == 'ssn_i') then
             call unpack_coupling_array(work, ssn)
+        elseif (trim(fields_from_ocn(i)) == 'ssalg_i') then
+            call unpack_coupling_array(work, ssalg)
         else
             call abort_ice('ice: bad coupling array name '//fields_from_ocn(i))
         endif
@@ -643,6 +648,8 @@ subroutine into_ocn(isteps, scale)
             call pack_coupling_array(iownd*scale, work)
         elseif (trim(fields_to_ocn(i)) == 'nit_io') then
             call pack_coupling_array(ionit*scale, work)
+        elseif (trim(fields_to_ocn(i)) == 'alg_io') then
+            call pack_coupling_array(ioalg*scale, work)
         else
             call abort_ice('ice: bad coupling array name '//fields_to_ocn(i))
         endif
@@ -709,7 +716,7 @@ end subroutine update_halos_from_atm
               tioqflux, tiolwflx, tioshflx, tiorunof, tiolicefw, tiolicefh, tiopress) 
   deallocate (iomelt, ioform, tiomelt, tioform)
   deallocate (iownd, tiownd)
-  deallocate (ionit, tionit, ssn)
+  deallocate (ionit, tionit, ssn, ioalg, tioalg, ssalg)
   deallocate (gwork, vwork, sicemass)
   !  
   ! PSMILe termination 
@@ -761,6 +768,7 @@ subroutine write_boundary_checksums(time)
      print*,   '[ice chksum] ioform:', sum(ioform(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iownd:', sum(iownd(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] ionit:', sum(ionit(isc:iec, jsc:jec, 1))
+     print*,   '[ice chksum] ioalg:', sum(ioalg(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iorunof:', sum(iorunof(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iolicefw:', sum(iolicefw(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iolicefh:', sum(iolicefh(isc:iec, jsc:jec, 1))
@@ -773,6 +781,7 @@ subroutine write_boundary_checksums(time)
      print*,   '[ice chksum] ssly:', sum(ssly(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] pfmice:', sum(pfmice(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] ssn:', sum(ssn(isc:iec, jsc:jec, 1))
+     print*,   '[ice chksum] ssalg:', sum(ssalg(isc:iec, jsc:jec, 1))
 
      print*,   '[ice chksum] swflx0:', sum(swflx0(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] lwflx0:', sum(lwflx0(isc:iec, jsc:jec, 1))

--- a/drivers/auscom/cpl_interface.F90
+++ b/drivers/auscom/cpl_interface.F90
@@ -291,6 +291,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
     allocate (sslx(nx_block, ny_block, max_blocks));  sslx(:,:,:) = 0
     allocate (ssly(nx_block, ny_block, max_blocks));  ssly(:,:,:) = 0
     allocate (pfmice(nx_block, ny_block, max_blocks));  pfmice(:,:,:) = 0
+    allocate (ssn(nx_block, ny_block, max_blocks));  ssn(:,:,:) = 0
 
     allocate (iostrsu(nx_block, ny_block, max_blocks)); iostrsu(:,:,:) = 0
     allocate (iostrsv(nx_block, ny_block, max_blocks)); iostrsv(:,:,:) = 0
@@ -312,6 +313,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
     allocate (iolicefh (nx_block, ny_block, max_blocks)); iolicefh(:,:,:) = 0
 
     allocate (iownd (nx_block, ny_block, max_blocks)); iownd(:,:,:) = 0
+    allocate (ionit (nx_block, ny_block, max_blocks)); ionit(:,:,:) = 0
 
     allocate (tiostrsu(nx_block, ny_block, max_blocks)); tiostrsu(:,:,:) = 0
     allocate (tiostrsv(nx_block, ny_block, max_blocks)); tiostrsv(:,:,:) = 0
@@ -331,6 +333,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
     allocate (tioform(nx_block, ny_block, max_blocks));  tioform(:,:,:) = 0
 
     allocate (tiownd (nx_block, ny_block, max_blocks)); tiownd(:,:,:) = 0
+    allocate (tionit (nx_block, ny_block, max_blocks)); tionit(:,:,:) = 0
 
     allocate (tiolicefw(nx_block, ny_block, max_blocks));  tiolicefw(:,:,:) = 0
     allocate (tiolicefh(nx_block, ny_block, max_blocks));  tiolicefh(:,:,:) = 0
@@ -571,6 +574,8 @@ subroutine from_ocn(isteps)
             call unpack_coupling_array(work, ssly)
         elseif (trim(fields_from_ocn(i)) == 'pfmice_i') then
             call unpack_coupling_array(work, pfmice)
+        elseif (trim(fields_from_ocn(i)) == 'ssn_i') then
+            call unpack_coupling_array(work, ssn)
         else
             call abort_ice('ice: bad coupling array name '//fields_from_ocn(i))
         endif
@@ -636,8 +641,8 @@ subroutine into_ocn(isteps, scale)
             call pack_coupling_array(iolicefh*scale, work)
         elseif (trim(fields_to_ocn(i)) == 'wnd10_io') then
             call pack_coupling_array(iownd*scale, work)
-        elseif (trim(fields_to_ocn(i)) == 'nitrate_io') then
-            call pack_coupling_array(ionitrate*scale, work)
+        elseif (trim(fields_to_ocn(i)) == 'nit_io') then
+            call pack_coupling_array(ionit*scale, work)
         else
             call abort_ice('ice: bad coupling array name '//fields_to_ocn(i))
         endif
@@ -704,6 +709,7 @@ end subroutine update_halos_from_atm
               tioqflux, tiolwflx, tioshflx, tiorunof, tiolicefw, tiolicefh, tiopress) 
   deallocate (iomelt, ioform, tiomelt, tioform)
   deallocate (iownd, tiownd)
+  deallocate (ionit, tionit, ssn)
   deallocate (gwork, vwork, sicemass)
   !  
   ! PSMILe termination 
@@ -754,6 +760,7 @@ subroutine write_boundary_checksums(time)
      print*,   '[ice chksum] iomelt:', sum(iomelt(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] ioform:', sum(ioform(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iownd:', sum(iownd(isc:iec, jsc:jec, 1))
+     print*,   '[ice chksum] ionit:', sum(ionit(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iorunof:', sum(iorunof(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iolicefw:', sum(iolicefw(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] iolicefh:', sum(iolicefh(isc:iec, jsc:jec, 1))
@@ -765,6 +772,7 @@ subroutine write_boundary_checksums(time)
      print*,   '[ice chksum] sslx:', sum(sslx(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] ssly:', sum(ssly(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] pfmice:', sum(pfmice(isc:iec, jsc:jec, 1))
+     print*,   '[ice chksum] ssn:', sum(ssn(isc:iec, jsc:jec, 1))
 
      print*,   '[ice chksum] swflx0:', sum(swflx0(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] lwflx0:', sum(lwflx0(isc:iec, jsc:jec, 1))

--- a/source/ice_algae.F90
+++ b/source/ice_algae.F90
@@ -198,7 +198,7 @@
                                       indxi,    indxj,     &
                                       nbtrcr,              &
                                       flux_bio, ocean_bio, &
-                                      hmix,     aicen,     &
+                                      dz_ocean1,     aicen,     &
                                       meltb,    congel,    &
                                       fswthru,  first_ice, &
                                       trcrn,    grow_Cn)
@@ -215,6 +215,7 @@
          indxi, indxj    ! compressed indices for cells with aicen > puny
 
       real (kind=dbl_kind), intent(in) :: &
+         dz_ocean1, &  ! first ocean layer thickness (m)
          dt         ! time step 
 
       logical (kind=log_kind), dimension (nx_block,ny_block), &
@@ -222,7 +223,6 @@
          first_ice  ! initialized values should be used
 
       real (kind=dbl_kind), dimension (nx_block,ny_block), intent(in) :: &
-         hmix   , & ! mixed layer depth (m)
          aicen  , & ! ice area 
          meltb  , & ! bottom ice melt (m)
          congel , & ! bottom ice growth (m)
@@ -468,7 +468,7 @@
          ! Currently not coupled with ocean biogeochemistry
          ! HH uncommented to enable ice-ocean BGC coupling for ACCESS-OM2
          ocean_bio(i,j,nn) = ocean_bio(i,j,nn) &
-                           + flux_bio(i,j,nn)/hmix(i,j)*aicen(i,j)
+                           + flux_bio(i,j,nn)/dz_ocean1*aicen(i,j)
 
          if (cinit(ij,nn) < c0) then
               write(nu_diag,*) 'sk_bgc < 0 after algal fluxes, ij,nn,cinit,flux_bio',&

--- a/source/ice_algae.F90
+++ b/source/ice_algae.F90
@@ -466,8 +466,9 @@
 
          ! Uncomment to update ocean concentration
          ! Currently not coupled with ocean biogeochemistry
-         !ocean_bio(i,j,nn) = ocean_bio(i,j,nn) &
-         !                  + flux_bio(i,j,nn)/hmix(i,j)*aicen(i,j)
+         ! HH uncommented to enable ice-ocean BGC coupling for ACCESS-OM2
+         ocean_bio(i,j,nn) = ocean_bio(i,j,nn) &
+                           + flux_bio(i,j,nn)/hmix(i,j)*aicen(i,j)
 
          if (cinit(ij,nn) < c0) then
               write(nu_diag,*) 'sk_bgc < 0 after algal fluxes, ij,nn,cinit,flux_bio',&

--- a/source/ice_algae.F90
+++ b/source/ice_algae.F90
@@ -198,7 +198,7 @@
                                       indxi,    indxj,     &
                                       nbtrcr,              &
                                       flux_bio, ocean_bio, &
-                                      dz_ocean1,     aicen,     &
+                                      aicen,     &
                                       meltb,    congel,    &
                                       fswthru,  first_ice, &
                                       trcrn,    grow_Cn)
@@ -215,7 +215,6 @@
          indxi, indxj    ! compressed indices for cells with aicen > puny
 
       real (kind=dbl_kind), intent(in) :: &
-         dz_ocean1, &  ! first ocean layer thickness (m)
          dt         ! time step 
 
       logical (kind=log_kind), dimension (nx_block,ny_block), &
@@ -466,9 +465,8 @@
 
          ! Uncomment to update ocean concentration
          ! Currently not coupled with ocean biogeochemistry
-         ! HH uncommented to enable ice-ocean BGC coupling for ACCESS-OM2
-         ocean_bio(i,j,nn) = ocean_bio(i,j,nn) &
-                           + flux_bio(i,j,nn)/dz_ocean1*aicen(i,j)
+         !ocean_bio(i,j,nn) = ocean_bio(i,j,nn) &
+         !                  + flux_bio(i,j,nn)/hmix(i,j)*aicen(i,j)
 
          if (cinit(ij,nn) < c0) then
               write(nu_diag,*) 'sk_bgc < 0 after algal fluxes, ij,nn,cinit,flux_bio',&

--- a/source/ice_zbgc.F90
+++ b/source/ice_zbgc.F90
@@ -57,7 +57,7 @@
          restore_bgc, skl_bgc, &
          tr_bgc_C_sk, tr_bgc_chl_sk, tr_bgc_Am_sk, tr_bgc_Sil_sk, &
          tr_bgc_DMSPp_sk, tr_bgc_DMSPd_sk, tr_bgc_DMS_sk, &
-         restart_bgc, restart_hbrine, phi_snow, bgc_flux_type, dz_ocean1
+         restart_bgc, restart_hbrine, phi_snow, bgc_flux_type
 
       !-----------------------------------------------------------------
       ! default values
@@ -80,7 +80,6 @@
       restart_hbrine  = .false.  ! hbrine restart
       phi_snow        = p5       ! snow porosity
       bgc_flux_type   = 'Jin2006'! type of ocean-ice poston velocity ('constant')
-      dz_ocean1       = 2.3035 ! HH first layer thickness of ocean
 
       !-----------------------------------------------------------------
       ! read from input file
@@ -182,7 +181,6 @@
       call broadcast_scalar(tr_bgc_DMSPp_sk,    master_task)
       call broadcast_scalar(tr_bgc_DMSPd_sk,    master_task)
       call broadcast_scalar(tr_bgc_DMS_sk,      master_task)
-      call broadcast_scalar(dz_ocean1,          master_task)
 
       if (skl_bgc) then
 
@@ -206,7 +204,6 @@
          write(nu_diag,1010) ' tr_bgc_DMSPp_sk           = ', tr_bgc_DMSPp_sk
          write(nu_diag,1010) ' tr_bgc_DMSPd_sk           = ', tr_bgc_DMSPd_sk
          write(nu_diag,1010) ' tr_bgc_DMS_sk             = ', tr_bgc_DMS_sk
-         write(nu_diag,1010) ' dz_ocean1                 = ', dz_ocean1
         
       endif   ! master_task
 
@@ -726,7 +723,6 @@
                                          nbtrcr,                        &
                                          flux_bion(:,:,1:nbtrcr),       &
                                          ocean_bio(:,:,1:nbtrcr, iblk), &
-                                         dz_ocean1                    , &
                                          aicen    (:,:,        n,iblk), & 
                                          meltbn   (:,:,        n,iblk), &
                                          congeln  (:,:,        n,iblk), &

--- a/source/ice_zbgc.F90
+++ b/source/ice_zbgc.F90
@@ -11,7 +11,7 @@
 
       use ice_kinds_mod
       use ice_zbgc_shared ! everything
-      use cpl_arrays_setup, only: ssn
+      use cpl_arrays_setup, only: ssn, ssalg
 
       implicit none 
 
@@ -621,7 +621,8 @@
             if (tr_bgc_DMSPp_sk) ocean_bio(i,j,nlt_bgc_DMSPp,iblk) = dmsp  (i,j,iblk)
             if (tr_bgc_DMSPd_sk) ocean_bio(i,j,nlt_bgc_DMSPd,iblk) = dmsp  (i,j,iblk)
             if (tr_bgc_DMS_sk)   ocean_bio(i,j,nlt_bgc_DMS  ,iblk) = dms   (i,j,iblk)
-            if (tr_bgc_N_sk)     ocean_bio(i,j,nlt_bgc_N    ,iblk) = algalN(i,j,iblk)
+            !if (tr_bgc_N_sk)     ocean_bio(i,j,nlt_bgc_N    ,iblk) = algalN(i,j,iblk)
+            if (tr_bgc_N_sk)     ocean_bio(i,j,nlt_bgc_N    ,iblk) = ssalg (i,j,iblk)
          enddo
          enddo
 

--- a/source/ice_zbgc.F90
+++ b/source/ice_zbgc.F90
@@ -57,7 +57,7 @@
          restore_bgc, skl_bgc, &
          tr_bgc_C_sk, tr_bgc_chl_sk, tr_bgc_Am_sk, tr_bgc_Sil_sk, &
          tr_bgc_DMSPp_sk, tr_bgc_DMSPd_sk, tr_bgc_DMS_sk, &
-         restart_bgc, restart_hbrine, phi_snow, bgc_flux_type
+         restart_bgc, restart_hbrine, phi_snow, bgc_flux_type, dz_ocean1
 
       !-----------------------------------------------------------------
       ! default values
@@ -80,6 +80,7 @@
       restart_hbrine  = .false.  ! hbrine restart
       phi_snow        = p5       ! snow porosity
       bgc_flux_type   = 'Jin2006'! type of ocean-ice poston velocity ('constant')
+      dz_ocean1       = 2.3035 ! HH first layer thickness of ocean
 
       !-----------------------------------------------------------------
       ! read from input file
@@ -181,6 +182,7 @@
       call broadcast_scalar(tr_bgc_DMSPp_sk,    master_task)
       call broadcast_scalar(tr_bgc_DMSPd_sk,    master_task)
       call broadcast_scalar(tr_bgc_DMS_sk,      master_task)
+      call broadcast_scalar(dz_ocean1,          master_task)
 
       if (skl_bgc) then
 
@@ -204,6 +206,7 @@
          write(nu_diag,1010) ' tr_bgc_DMSPp_sk           = ', tr_bgc_DMSPp_sk
          write(nu_diag,1010) ' tr_bgc_DMSPd_sk           = ', tr_bgc_DMSPd_sk
          write(nu_diag,1010) ' tr_bgc_DMS_sk             = ', tr_bgc_DMS_sk
+         write(nu_diag,1010) ' dz_ocean1                 = ', dz_ocean1
         
       endif   ! master_task
 
@@ -723,7 +726,7 @@
                                          nbtrcr,                        &
                                          flux_bion(:,:,1:nbtrcr),       &
                                          ocean_bio(:,:,1:nbtrcr, iblk), &
-                                         hmix     (:,:,          iblk), &
+                                         dz_ocean1                    , &
                                          aicen    (:,:,        n,iblk), & 
                                          meltbn   (:,:,        n,iblk), &
                                          congeln  (:,:,        n,iblk), &

--- a/source/ice_zbgc.F90
+++ b/source/ice_zbgc.F90
@@ -11,6 +11,7 @@
 
       use ice_kinds_mod
       use ice_zbgc_shared ! everything
+      use cpl_arrays_setup, only: ssn
 
       implicit none 
 
@@ -612,7 +613,7 @@
          ! Define ocean tracer concentration
          do j = 1, ny_block
          do i = 1, nx_block
-            if (tr_bgc_Nit_sk)   ocean_bio(i,j,nlt_bgc_NO   ,iblk) = nit   (i,j,iblk)
+            if (tr_bgc_Nit_sk)   ocean_bio(i,j,nlt_bgc_NO   ,iblk) = ssn   (i,j,iblk)
             if (tr_bgc_chl_sk)   ocean_bio(i,j,nlt_bgc_chl  ,iblk) = algalN(i,j,iblk)*R_chl2N
             if (tr_bgc_Am_sk)    ocean_bio(i,j,nlt_bgc_NH   ,iblk) = amm   (i,j,iblk)
             if (tr_bgc_C_sk)     ocean_bio(i,j,nlt_bgc_C    ,iblk) = algalN(i,j,iblk)*R_C2N

--- a/source/ice_zbgc_shared.F90
+++ b/source/ice_zbgc_shared.F90
@@ -126,7 +126,7 @@
          thinS     = 0.05_dbl_kind     ! minimum ice thickness for brine
 
       real (kind=dbl_kind), public :: & 
-         dz_ocean1  = 2.03035_dbl_kind,  & ! first ocean layer thickness (m)
+         dz_ocean1  = 2.3035_dbl_kind,  & ! first ocean layer thickness (m)
          phi_snow ,  &  ! porosity of snow
          flood_frac     ! fraction of ocean/meltwater that floods
 

--- a/source/ice_zbgc_shared.F90
+++ b/source/ice_zbgc_shared.F90
@@ -126,7 +126,6 @@
          thinS     = 0.05_dbl_kind     ! minimum ice thickness for brine
 
       real (kind=dbl_kind), public :: & 
-         dz_ocean1  = 2.3035_dbl_kind,  & ! first ocean layer thickness (m)
          phi_snow ,  &  ! porosity of snow
          flood_frac     ! fraction of ocean/meltwater that floods
 

--- a/source/ice_zbgc_shared.F90
+++ b/source/ice_zbgc_shared.F90
@@ -126,6 +126,7 @@
          thinS     = 0.05_dbl_kind     ! minimum ice thickness for brine
 
       real (kind=dbl_kind), public :: & 
+         dz_ocean1  = 2.03035_dbl_kind,  & ! first ocean layer thickness (m)
          phi_snow ,  &  ! porosity of snow
          flood_frac     ! fraction of ocean/meltwater that floods
 


### PR DESCRIPTION
Dear the ACCESS-OM2 development team,

I have updated the MOM and CICE code for the 4th cycle of 0.1-degree run and IAMIP2. All updates are related to BGC:

1) activated the BGC coupling between the ocean and sea ice. This required addition of 4 tracers to be coupled.
2) addition of extra diagnostics, such as net primary productivity, photosynthetically active radiation, and export production at 100 m.

These updates have no effect on physics, and there should be no conflict with the current master branch.

Accordingly, we need to update input files (e.g. i2o.nc o2i.nc) as well as config (e.g. 1deg_jra55_iaf).

Let me know how we can proceed. It would be great if @russfiedler could double check these updates. I will ask others within my circle to check as well.