### PR TITLE
Add support for providing relative humidity rather than specific humidity as an input file

### DIFF
--- a/drivers/auscom/cpl_arrays_setup.F90
+++ b/drivers/auscom/cpl_arrays_setup.F90
@@ -21,6 +21,7 @@ module cpl_arrays_setup
 ! (9) pressure            (Pa)                          press0
 ! (10)runof               (kg/m^2/s)                    runof0 
 ! (11)calving               (kg/m^2/s)                  calv0 
+! (12)rel humidity          (kg/kg%)                    relh0 
 !
 ! B> ocn==>ice 
 !                          
@@ -87,7 +88,7 @@ implicit none
 
 ! Fields in
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: &   !from atm
-    tair0, swflx0, lwflx0, uwnd0, vwnd0, qair0, rain0, snow0 & !(for ice)
+    tair0, swflx0, lwflx0, uwnd0, vwnd0, qair0, rain0, snow0, relh0 & !(for ice)
    ,runof0, press0, calv0                                      !(for ocn)    
 
 real(kind=dbl_kind), dimension(:,:,:), allocatable :: runof, calv, press

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1354,7 +1354,7 @@ allocate(e_sat,mold=temp)
 ! Series, Elsevier.
 
 ! Calculate saturated vapor pressure using Clausius-Clapeyron:
-e_sat = esref*exp((Lvap/rvgas)*(c1/Tffresh-c1/min(max(temp,c114),c373))
+e_sat = esref*exp((Lvap/rvgas)*(c1/Tffresh-c1/min(max(temp,c114),c373)))
 
 ! Calculate specific humidity from relative:
 where (press /= c0 ) q = d622*(rh/c100)*e_sat/(press-d378*(rh/c100)*e_sat)

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1349,8 +1349,9 @@ real (kind=dbl_kind), intent(inout), dimension(:,:,:) :: q
 real (kind=dbl_kind),allocatable,dimension(:,:,:) :: e_sat
 
 allocate(e_sat,mold=temp)
-!Make sure temp is in range
-call escomp(max(temp-273.15_dbl_kind,80.0_dbl_kind),e_sat)
+!Make sure temp is in range.
+!From sat_vapor_pres_mod.F90, tcmin = -160C and tcmax=100C
+call escomp(min(max(temp,114.0_dbl_kind),373.0_dbl_kind),e_sat)
 !e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./temp)
 where (press /= 0.0_dbl_kind ) q = 0.622_dbl_kind*(rh/100.0_dbl_kind)*e_sat/(press-0.378_dbl_kind*(rh/100.0_dbl_kind)*e_sat)
 deallocate(e_sat)

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1357,7 +1357,7 @@ allocate(e_sat,mold=temp)
 e_sat = esref*exp((Lvap/rvgas)*(c1/Tffresh-c1/min(max(temp,c114),c373)))
 
 ! Calculate specific humidity from relative:
-where (press /= c0 ) q = d622*(rh/c100)*e_sat/(press-d378*(rh/c100)*e_sat)
+where (press /= c0 ) q = rtgas*(rh/c100)*e_sat/(press-(c1-rtgas)*(rh/c100)*e_sat)
 deallocate(e_sat)
 
 end subroutine rh2q

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1349,10 +1349,15 @@ real (kind=dbl_kind), intent(inout), dimension(:,:,:) :: q
 real (kind=dbl_kind),allocatable,dimension(:,:,:) :: e_sat
 
 allocate(e_sat,mold=temp)
-!Make sure temp is in range.
-!From sat_vapor_pres_mod.F90, tcmin = -160C and tcmax=100C
-call escomp(min(max(temp,114.0_dbl_kind),373.0_dbl_kind),e_sat)
-!e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./temp)
+
+! Look-up table approach (consistent with internals):
+! Make sure temp is in range.
+! From sat_vapor_pres_mod.F90, tcmin = -160C and tcmax=100C
+! call escomp(min(max(temp,114.0_dbl_kind),373.0_dbl_kind),e_sat)
+
+! Simple approach (for use with simple pre-processing):
+e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./min(max(temp,114.0_dbl_kind),373.0_dbl_kind)))
+
 where (press /= 0.0_dbl_kind ) q = 0.622_dbl_kind*(rh/100.0_dbl_kind)*e_sat/(press-0.378_dbl_kind*(rh/100.0_dbl_kind)*e_sat)
 deallocate(e_sat)
 

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -24,6 +24,8 @@ module cpl_forcing_handler
     use cpl_arrays_setup
     use ice_calendar, only: dt
 
+    use  sat_vapor_pres_mod, only: escomp, descomp !RASF not sure why descomp is needed but it is like this in surface_flux_mod
+
 implicit none
 
 contains
@@ -1338,5 +1340,22 @@ inquire (file=trim(file_name), exist=file_exist)
 end function file_exist
 
 !============================================================================
+
+subroutine rh2q(temp,rh,press,q)
+!Convert relative humidity to specific humidity
+implicit none
+real (kind=dbl_kind), intent(in), dimension(:,:,:) :: temp,rh,press
+real (kind=dbl_kind), intent(inout), dimension(:,:,:) :: q
+real (kind=dbl_kind),allocatable,dimension(:,:,:) :: e_sat
+
+allocate(e_sat,mold=temp)
+!Make sure temp is in range
+call escomp(max(temp,200.0_dbl_kind),e_sat)
+!e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./temp)
+where (press /= 0.0_dbl_kind ) q = 0.622_dbl_kind*(rh/100.0_dbl_kind)*e_sat/(press-0.378_dbl_kind*(rh/100.0_dbl_kind)*e_sat)
+deallocate(e_sat)
+
+end subroutine rh2q
+
 
 end module cpl_forcing_handler

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -24,7 +24,8 @@ module cpl_forcing_handler
     use cpl_arrays_setup
     use ice_calendar, only: dt
 
-    use  sat_vapor_pres_mod, only: escomp, descomp !RASF not sure why descomp is needed but it is like this in surface_flux_mod
+! For use in rh2q if using lookup table approach:
+!    use  sat_vapor_pres_mod, only: escomp, descomp !RASF not sure why descomp is needed but it is like this in surface_flux_mod
 
 implicit none
 

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1350,7 +1350,7 @@ real (kind=dbl_kind),allocatable,dimension(:,:,:) :: e_sat
 
 allocate(e_sat,mold=temp)
 !Make sure temp is in range
-call escomp(max(temp,400.0_dbl_kind),e_sat)
+call escomp(max(temp,350.0_dbl_kind),e_sat)
 !e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./temp)
 where (press /= 0.0_dbl_kind ) q = 0.622_dbl_kind*(rh/100.0_dbl_kind)*e_sat/(press-0.378_dbl_kind*(rh/100.0_dbl_kind)*e_sat)
 deallocate(e_sat)

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1350,7 +1350,7 @@ real (kind=dbl_kind),allocatable,dimension(:,:,:) :: e_sat
 
 allocate(e_sat,mold=temp)
 !Make sure temp is in range
-call escomp(max(temp,350.0_dbl_kind),e_sat)
+call escomp(max(temp-273.15_dbl_kind,80.0_dbl_kind),e_sat)
 !e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./temp)
 where (press /= 0.0_dbl_kind ) q = 0.622_dbl_kind*(rh/100.0_dbl_kind)*e_sat/(press-0.378_dbl_kind*(rh/100.0_dbl_kind)*e_sat)
 deallocate(e_sat)

--- a/drivers/auscom/cpl_forcing_handler.F90
+++ b/drivers/auscom/cpl_forcing_handler.F90
@@ -1350,7 +1350,7 @@ real (kind=dbl_kind),allocatable,dimension(:,:,:) :: e_sat
 
 allocate(e_sat,mold=temp)
 !Make sure temp is in range
-call escomp(max(temp,200.0_dbl_kind),e_sat)
+call escomp(max(temp,400.0_dbl_kind),e_sat)
 !e_sat = 6.11d2*exp((2.5d6/462.52d0)*(1.d0/273.15-1./temp)
 where (press /= 0.0_dbl_kind ) q = 0.622_dbl_kind*(rh/100.0_dbl_kind)*e_sat/(press-0.378_dbl_kind*(rh/100.0_dbl_kind)*e_sat)
 deallocate(e_sat)

--- a/drivers/auscom/cpl_interface.F90
+++ b/drivers/auscom/cpl_interface.F90
@@ -277,6 +277,7 @@ subroutine init_cpl(runtime_seconds, coupling_field_timesteps)
     allocate (snow0(nx_block, ny_block, max_blocks));  snow0(:,:,:) = 0
     allocate (runof0(nx_block, ny_block, max_blocks)); runof0(:,:,:) = 0
     allocate (press0(nx_block, ny_block, max_blocks)); press0(:,:,:) = 0
+    allocate (relh0(nx_block, ny_block, max_blocks));  relh0(:,:,:) = 0
 
     allocate (runof(nx_block, ny_block, max_blocks)); runof(:,:,:) = 0
     allocate (calv(nx_block, ny_block, max_blocks)); calv(:,:,:) = 0
@@ -467,11 +468,13 @@ subroutine from_atm(isteps)
     integer(kind=int_kind) :: tag, request, info
     integer(kind=int_kind) :: buf(1)
     real(kind=dbl_kind), dimension(block_size_x*block_size_y*nblocks) :: work
+    logical :: do_relh
 
 #if defined(DEBUG)
     write(il_out,*) '(from_atm) receiving coupling fields at rtime= ', isteps
 #endif
 
+    do_relh = .false.
     call ice_timer_start(timer_from_atm)
 
     do i=1, num_fields_from_atm
@@ -506,6 +509,9 @@ subroutine from_atm(isteps)
             call unpack_coupling_array(work, vwnd0)
         elseif (trim(fields_from_atm(i)) == 'licalvf_i') then
             call unpack_coupling_array(work, calv0)
+        elseif (trim(fields_from_atm(i)) == 'relh_i') then
+                do_relh = .true.
+            call unpack_coupling_array(work, relh0)
         else
             call abort_ice('ice: bad coupling array name '//fields_from_atm(i))
         endif
@@ -518,6 +524,10 @@ subroutine from_atm(isteps)
     !call t2ugrid(vwnd1)
     ! ...and, as we use direct o-i communication and o-i share the same grid, 
     ! no need for any t2u and/or u2t shift before/after i-o coupling!
+
+    if (  do_relh ) then
+      call rh2q(tair0, relh0, press0, qair0)  !In cpl_forcing_handler_mod
+    endif
 
     if ( chk_a2i_fields ) then
       call check_a2i_fields('fields_a2i_in_ice.nc',isteps)
@@ -692,7 +702,7 @@ end subroutine update_halos_from_atm
   subroutine coupler_termination
 !-------------------------------!
 
-  deallocate (tair0, swflx0, lwflx0, uwnd0, vwnd0, qair0, rain0, snow0, runof0, press0)
+  deallocate (tair0, swflx0, lwflx0, uwnd0, vwnd0, qair0, rain0, snow0, runof0, press0, relh0)
   deallocate (runof, calv, press)
   deallocate (core_runoff)
   deallocate (ssto, ssso, ssuo, ssvo, sslx, ssly, pfmice)
@@ -775,6 +785,7 @@ subroutine write_boundary_checksums(time)
      print*,   '[ice chksum] uwnd0:',  sum(uwnd0(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] vwnd0:',  sum(vwnd0(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] calv0:',  sum(calv0(isc:iec, jsc:jec, 1))
+     print*,   '[ice chksum] relh0:',  sum(relh0(isc:iec, jsc:jec, 1))
 
      print*,   '[ice chksum] u_star0:', sum(u_star0(isc:iec, jsc:jec, 1))
      print*,   '[ice chksum] rough_mom0:', sum(rough_mom0(isc:iec, jsc:jec, 1))

--- a/drivers/auscom/ice_constants.F90
+++ b/drivers/auscom/ice_constants.F90
@@ -158,9 +158,11 @@
         c25  = 25.0_dbl_kind, &
 	c30  = 30.0_dbl_kind, &
         c100 = 100.0_dbl_kind, &
+        c114 = 114.0_dbl_kind, &
         c180 = 180.0_dbl_kind, &
         c360 = 360.0_dbl_kind, &
         c365 = 365.0_dbl_kind, &
+        c373 = 373.0_dbl_kind, &
 	c400 = 400.0_dbl_kind, &
         c3600= 3600.0_dbl_kind, &
         c1000= 1000.0_dbl_kind, &
@@ -233,7 +235,8 @@
 !ars599: 26032014: change to public
       real (kind=dbl_kind), parameter, public :: &
         rvgas = 461.50_dbl_kind         ,&! gas constant for water vapour
-        rdgas = 287.04_dbl_kind           ! gas constant for dry air 
+        rdgas = 287.04_dbl_kind         ,&! gas constant for dry air
+        esref = 611.00_dbl_kind           ! saturation vapor pressure at 273.15K
 #endif
 !=======================================================================
 

--- a/drivers/auscom/ice_constants.F90
+++ b/drivers/auscom/ice_constants.F90
@@ -236,7 +236,8 @@
       real (kind=dbl_kind), parameter, public :: &
         rvgas = 461.50_dbl_kind         ,&! gas constant for water vapour
         rdgas = 287.04_dbl_kind         ,&! gas constant for dry air
-        esref = 611.00_dbl_kind           ! saturation vapor pressure at 273.15K
+        esref = 611.00_dbl_kind         ,&! saturation vapor pressure at 273.15K
+        rtgas = rdgas/rvgas               ! ratio of gas constants
 #endif
 !=======================================================================
 


### PR DESCRIPTION
This approach uses a simpler formula for converting RH to QH than used by the model internals. This should not be an issue provided the same formula is used for the pre-processing when the JRA55-do provided QH is converted to RH. 